### PR TITLE
support linking directly to a channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is a small wrapper around [slackin](https://github.com/rauchg/slackin) to a
     * Who will be the moderators
 1. Drop the link to the pull request into #wg-opensource.
 
+Once merged and [deployed](#production), you can link to `https://chat.18f.gov/?channel=<name>` from your project/repository/etc.
+
 ## Setup
 
 ### Local

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
   },
   "dependencies": {
     "gulp": "^3.9.1",
-    "slackin": "^0.8.3"
+    "slackin": "18F/slackin#link-to-channel"
   }
 }


### PR DESCRIPTION
See https://github.com/rauchg/slackin/pull/183. Switching to using that branch of slackin until the pull request is (hopefully) merged and released.

/cc @konklone @adrianwebb @gbinal 
